### PR TITLE
14/12/2016 - Update the sha256sum of nginx signing key (centos only).

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -3,7 +3,7 @@
   template: src=nginx_centos.repo.j2 dest=/etc/yum.repos.d/nginx.repo owner=root group=root mode=0644
 
 - name: Add repo key
-  get_url: url=http://nginx.org/keys/nginx_signing.key dest=/etc/pki/rpm-gpg/RPM-GPG-KEY-nginx sha256sum=dcc2ed613d67b277a7e7c87b12907485652286e199c1061fb4b3af91f201be39 force=yes
+  get_url: url=http://nginx.org/keys/nginx_signing.key dest=/etc/pki/rpm-gpg/RPM-GPG-KEY-nginx sha256sum=dd4da5dc599ef9e7a7ac20a87275024b4923a917a306ab5d53fa77871220ecda force=yes
 
 - name: Add repo key
   file: path=/etc/pki/rpm-gpg/RPM-GPG-KEY-nginx owner=root group=root mode=0644


### PR DESCRIPTION
14/12/2016 - Update the sha256sum of nginx signing key.
The old key was out of date. Which then lead to nginx failed installation. 